### PR TITLE
Add print statement if smoke fails to start so user knows what cause was

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "smoke"
 
 organization := "com.mdialog"
 
-version := "0.6.1"
+version := "0.6.2"
 
 scalaVersion := "2.10.2"
 

--- a/src/main/scala/smoke/netty/NettyServer.scala
+++ b/src/main/scala/smoke/netty/NettyServer.scala
@@ -46,7 +46,7 @@ class NettyServer(implicit val config: Config, system: ActorSystem)
         println("\taccepting %s connections on port %d".format(info.protocol, info.port))
       } catch {
         case e: Exception ⇒
-          println("\tERROR - not listening on port " + info.port)
+          println("\tERROR - not listening on port " + info.port + " due to exception: " + e)
           throw e
       }
     }


### PR DESCRIPTION
Took me a few minutes to figure out smoke wasn't able to bind to a port because it was in use so I thought this would be a helpful change.

It will print a message like this:
    ERROR - not listening on port 7771 due to exception: org.jboss.netty.channel.ChannelException: Failed to bind to: 0.0.0.0/0.0.0.0:7771
