### PR TITLE
StaticAsset look for the provided folder in the class path.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -58,7 +58,7 @@ smoke {
     cache-assets = true
     cache-assets-preload = false
     
-    public-dir = "src/main/resources/public"
+    public-dir = "public"
   }
 }
 

--- a/src/main/scala/smoke/StaticAssets.scala
+++ b/src/main/scala/smoke/StaticAssets.scala
@@ -10,7 +10,11 @@ object StaticAssets {
   def apply(publicFolder: String) = Props(classOf[StaticAssets], publicFolder)
 }
 
-class StaticAssets(publicFolder: String) extends Actor {
+class StaticAssets(publicFolderPath: String) extends Actor {
+  val publicFolder = Option(this.getClass.getClassLoader.getResource(publicFolderPath)) match {
+    case Some(url) ⇒ url.toString.split("file:").last
+    case _         ⇒ throw new Exception("Error: static assets folder not accessible")
+  }
 
   val config = context.system.settings.config
 

--- a/src/test/scala/smoke/StaticAssetsTest.scala
+++ b/src/test/scala/smoke/StaticAssetsTest.scala
@@ -12,7 +12,7 @@ class StaticAssetsTest extends TestKit(ActorSystem("StaticAssetsTest"))
 
   describe("when asset does not exist") {
     it("should respond with 404") {
-      val actor = system.actorOf(StaticAssets("src/test/resources/public"))
+      val actor = system.actorOf(StaticAssets("public"))
 
       actor ! "/not-a-test-asset.html"
 
@@ -22,7 +22,7 @@ class StaticAssetsTest extends TestKit(ActorSystem("StaticAssetsTest"))
 
   describe("when asset does exist") {
     it("should respond with asset") {
-      val actor = system.actorOf(StaticAssets("src/test/resources/public"))
+      val actor = system.actorOf(StaticAssets("public"))
 
       import java.io.{ File, FileInputStream }
       val file = new File("src/test/resources/public/test-asset.html")


### PR DESCRIPTION
StaticAssets now finds the public folder using the classloader. This way, it does not matter if it's in src/main/resources or bundle.
