### PR TITLE
Add content-type extractor and improve Seg, Filename and Extension extractors.

### DIFF
--- a/src/main/scala/smoke/examples/FileNameExampleApp.scala
+++ b/src/main/scala/smoke/examples/FileNameExampleApp.scala
@@ -8,7 +8,7 @@ object FileNameExampleApp extends SmokeApp {
 
   val executionContext = scala.concurrent.ExecutionContext.global
   onRequest {
-    case GET(Path(Seg("products" :: productId :: FileName("orders" :: extension :: Nil) :: Nil))) ⇒ reply {
+    case GET(Seg("products" :: productId :: "orders" :: extension :: Nil)) ⇒ reply {
       val responseText = extension match {
         case "xml"  ⇒ "<product id=\"${productId}\"><orders /></product>"
         case "json" ⇒ "{ product: { orders: [] } }"
@@ -17,7 +17,7 @@ object FileNameExampleApp extends SmokeApp {
       Response(Ok, body = responseText)
     }
 
-    case GET(Path(Seg("products" :: productId :: FileName("orders" :: Nil) :: Nil))) ⇒ reply {
+    case GET(Seg("products" :: productId :: "orders" :: Nil)) ⇒ reply {
       Response(Ok, body = "No extension")
     }
 
@@ -26,7 +26,7 @@ object FileNameExampleApp extends SmokeApp {
     //  Response(Ok, body = "No extension")
     //}
 
-    case GET(Path(Seg("products" :: productId :: "docs" :: FileName(document :: "txt" :: Nil) :: Nil))) ⇒ reply {
+    case GET(Seg("products" :: productId :: "docs" :: document :: "txt" :: Nil)) ⇒ reply {
 
       document match {
         case "manual"   ⇒ Response(Ok, body = "1. Purchase our product. 2. ??? 3. Profit!")

--- a/src/main/scala/smoke/examples/FileServerApp.scala
+++ b/src/main/scala/smoke/examples/FileServerApp.scala
@@ -12,7 +12,7 @@ class FileServerSmoke extends Smoke {
   val executionContext = scala.concurrent.ExecutionContext.global
 
   onRequest {
-    case GET(Path(path) & Path(FileExtension(extension))) ⇒ reply {
+    case GET(Path(path) & FileExtension(extension)) ⇒ reply {
       //serve files in the src/test/resources folder
       val fullPath = "src/test/resources" + path
 

--- a/src/test/scala/smoke/ExtractorsTest.scala
+++ b/src/test/scala/smoke/ExtractorsTest.scala
@@ -30,38 +30,62 @@ class ExtractorsTest extends FunSpec {
       expectResult(Some("m3u8"))(FileExtension.unapply("foo.m3u8"))
     }
 
+    it("should extract extension with multiple periods") {
+      expectResult(Some("m3u8"))(FileExtension.unapply("foo.bar.baz.m3u8"))
+    }
+
+    it("should extract extension in a path") {
+      expectResult(Some("m3u8"))(FileExtension.unapply("/foo/path/foo.m3u8"))
+    }
+
+    it("should return none if the file does not have extension") {
+      expectResult(None)(FileExtension.unapply("/foo/path/foo"))
+    }
+
+    it("should return none if the filename ends with a period") {
+      expectResult(None)(FileExtension.unapply("/foo/path/foo."))
+    }
+
     it("should not return a file extension") {
       expectResult(None)(FileExtension.unapply("foo"))
     }
   }
 
-  describe("Test FileName") {
-    it("should extract a filename and extension") {
-      expectResult(Some(List("foo", "m3u8")))(FileName.unapply("foo.m3u8"))
-    }
+  describe("Filename") {
 
     it("should extract filenames with multiple periods") {
-      expectResult(Some(List("foo.bar.baz", "m3u8")))(FileName.unapply("foo.bar.baz.m3u8"))
+      expectResult(Some("foo.bar.baz.m3u8"))(Filename.unapply("/path/foo.bar.baz.m3u8"))
     }
 
     it("should extract filenames with path segments") {
-      expectResult(Some(List("/foo/bar/baz", "m3u8")))(FileName.unapply("/foo/bar/baz.m3u8"))
+      expectResult(Some("baz.m3u8"))(Filename.unapply("/foo/bar/baz.m3u8"))
     }
 
     it("should extract a filename with no extension") {
-      expectResult(Some(List("foo")))(FileName.unapply("foo"))
+      expectResult(Some("foo"))(Filename.unapply("foo"))
     }
 
     it("should extract a filename ending with a period but no extension") {
-      expectResult(Some(List("foo")))(FileName.unapply("foo."))
-    }
-
-    it("should extract an empty filename an extension") {
-      expectResult(Some(List("", "foo")))(FileName.unapply(".foo"))
+      expectResult(Some("foo."))(Filename.unapply("foo."))
     }
 
     it("should return None for an empty string") {
-      expectResult(None)(FileName.unapply(""))
+      expectResult(None)(Filename.unapply(""))
+    }
+  }
+
+  describe("ContentType") {
+    it("should extract type based on the extension first") {
+      val req = new test.TestRequest("http://test.com/test.xml")
+      expectResult(Some("application/xml"))(ContentType.unapply(req))
+    }
+    it("should extract type based on the header if there is no extension") {
+      val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "application/xml"))
+      expectResult(Some("application/xml"))(ContentType.unapply(req))
+    }
+    it("should extract type based on the last header if there is no extension and multiple headers") {
+      val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "application/json", "Accept" -> "application/xml"))
+      expectResult(Some("application/json"))(ContentType.unapply(req))
     }
   }
 

--- a/src/test/scala/smoke/StaticAssetsTest.scala
+++ b/src/test/scala/smoke/StaticAssetsTest.scala
@@ -1,8 +1,6 @@
 package smoke
 
 import org.scalatest.FunSpec
-import akka.testkit.{ TestKit, ImplicitSender }
-import akka.actor.ActorSystem
 import scala.concurrent.duration.Duration
 
 import smoke.test._


### PR DESCRIPTION
Seg will now split the path and the extension ( /a/b/c.d -> List("a","b","c","d") )
Add ContentType extractor that looks for extenstion first and then Accept header.
Filename extractor now returns the filename instead of a list of Name/Extension
