### PR TITLE
Fix filename extractors. Add Accept extractor

### DIFF
--- a/src/main/scala/smoke/MimeType.scala
+++ b/src/main/scala/smoke/MimeType.scala
@@ -2,7 +2,7 @@ package smoke
 
 object MimeType {
 
-  def apply(extension: String) =
+  def apply(extension: String): String =
     types.get(s".$extension").getOrElse("application/octet-stream")
 
   // Seeded with gratitude by the set from Rack 

--- a/src/main/scala/smoke/Request.scala
+++ b/src/main/scala/smoke/Request.scala
@@ -29,6 +29,15 @@ trait Request extends Headers {
 
   val contentLength: Int
 
+  //Sort accept header by given priority (q=?)
+  lazy val accept: Seq[String] =
+    allHeaderValues("accept").map {
+      _.split(";").toList match {
+        case mt :: p :: Nil ⇒ (mt, p.split("q=").last.toFloat)
+        case mt :: _        ⇒ (mt, 1.0f)
+      }
+    }.sortWith((a, b) ⇒ a._2 > b._2).map(_._1)
+
   override def toString = method + " - " + path + "-" + headers + "-" + "\n" + body
 
   protected def parseParams(params: String) =

--- a/src/main/scala/smoke/examples/FileNameExampleApp.scala
+++ b/src/main/scala/smoke/examples/FileNameExampleApp.scala
@@ -8,7 +8,7 @@ object FileNameExampleApp extends SmokeApp {
 
   val executionContext = scala.concurrent.ExecutionContext.global
   onRequest {
-    case GET(Seg("products" :: productId :: "orders" :: extension :: Nil)) ⇒ reply {
+    case GET(Seg("products" :: productId :: Filename("orders", extension) :: Nil)) ⇒ reply {
       val responseText = extension match {
         case "xml"  ⇒ "<product id=\"${productId}\"><orders /></product>"
         case "json" ⇒ "{ product: { orders: [] } }"
@@ -26,7 +26,7 @@ object FileNameExampleApp extends SmokeApp {
     //  Response(Ok, body = "No extension")
     //}
 
-    case GET(Seg("products" :: productId :: "docs" :: document :: "txt" :: Nil)) ⇒ reply {
+    case GET(Seg("products" :: productId :: "docs" :: _ :: Nil) & Filename.name(document)) ⇒ reply {
 
       document match {
         case "manual"   ⇒ Response(Ok, body = "1. Purchase our product. 2. ??? 3. Profit!")

--- a/src/main/scala/smoke/examples/FileServerApp.scala
+++ b/src/main/scala/smoke/examples/FileServerApp.scala
@@ -12,7 +12,7 @@ class FileServerSmoke extends Smoke {
   val executionContext = scala.concurrent.ExecutionContext.global
 
   onRequest {
-    case GET(Path(path) & FileExtension(extension)) ⇒ reply {
+    case GET(Path(path) & Filename.extension(extension)) ⇒ reply {
       //serve files in the src/test/resources folder
       val fullPath = "src/test/resources" + path
 

--- a/src/test/scala/smoke/ExtractorsTest.scala
+++ b/src/test/scala/smoke/ExtractorsTest.scala
@@ -25,48 +25,22 @@ class ExtractorsTest extends FunSpec {
     }
   }
 
-  describe("Test FileExtension") {
-    it("should return a file extension") {
-      expectResult(Some("m3u8"))(FileExtension.unapply("foo.m3u8"))
-    }
-
-    it("should extract extension with multiple periods") {
-      expectResult(Some("m3u8"))(FileExtension.unapply("foo.bar.baz.m3u8"))
-    }
-
-    it("should extract extension in a path") {
-      expectResult(Some("m3u8"))(FileExtension.unapply("/foo/path/foo.m3u8"))
-    }
-
-    it("should return none if the file does not have extension") {
-      expectResult(None)(FileExtension.unapply("/foo/path/foo"))
-    }
-
-    it("should return none if the filename ends with a period") {
-      expectResult(None)(FileExtension.unapply("/foo/path/foo."))
-    }
-
-    it("should not return a file extension") {
-      expectResult(None)(FileExtension.unapply("foo"))
-    }
-  }
-
   describe("Filename") {
 
     it("should extract filenames with multiple periods") {
-      expectResult(Some("foo.bar.baz.m3u8"))(Filename.unapply("/path/foo.bar.baz.m3u8"))
+      expectResult(Some("foo.bar.baz", "m3u8"))(Filename.unapply("/path/foo.bar.baz.m3u8"))
     }
 
     it("should extract filenames with path segments") {
-      expectResult(Some("baz.m3u8"))(Filename.unapply("/foo/bar/baz.m3u8"))
+      expectResult(Some("baz", "m3u8"))(Filename.unapply("/foo/bar/baz.m3u8"))
     }
 
     it("should extract a filename with no extension") {
-      expectResult(Some("foo"))(Filename.unapply("foo"))
+      expectResult(Some("foo", ""))(Filename.unapply("foo"))
     }
 
     it("should extract a filename ending with a period but no extension") {
-      expectResult(Some("foo."))(Filename.unapply("foo."))
+      expectResult(Some("foo", ""))(Filename.unapply("foo."))
     }
 
     it("should return None for an empty string") {
@@ -74,18 +48,71 @@ class ExtractorsTest extends FunSpec {
     }
   }
 
-  describe("ContentType") {
+  describe("Test Filename.extension") {
+    it("should return a file extension") {
+      expectResult(Some("m3u8"))(Filename.extension.unapply("foo.m3u8"))
+    }
+
+    it("should extract extension with multiple periods") {
+      expectResult(Some("m3u8"))(Filename.extension.unapply("foo.bar.baz.m3u8"))
+    }
+
+    it("should extract extension in a path") {
+      expectResult(Some("m3u8"))(Filename.extension.unapply("/foo/path/foo.m3u8"))
+    }
+
+    it("should return none if the file does not have extension") {
+      expectResult(None)(Filename.extension.unapply("/foo/path/foo"))
+    }
+
+    it("should return none if the filename ends with a period") {
+      expectResult(None)(Filename.extension.unapply("/foo/path/foo."))
+    }
+
+    it("should not return a file extension") {
+      expectResult(None)(Filename.extension.unapply("foo"))
+    }
+  }
+
+  describe("Filename.name") {
+
+    it("should extract basename with multiple periods") {
+      expectResult(Some("foo.bar.baz"))(Filename.name.unapply("/path/foo.bar.baz.m3u8"))
+    }
+
+    it("should extract basename with path segments") {
+      expectResult(Some("baz"))(Filename.name.unapply("/foo/bar/baz.m3u8"))
+    }
+
+    it("should extract a basename with no extension") {
+      expectResult(Some("foo"))(Filename.name.unapply("foo"))
+    }
+
+    it("should extract a basename ending with a period but no extension") {
+      expectResult(Some("foo"))(Filename.name.unapply("foo."))
+    }
+
+    it("should return None when it's an extension only") {
+      expectResult(None)(Filename.name.unapply(".foo"))
+    }
+
+    it("should return None for an empty string") {
+      expectResult(None)(Filename.name.unapply(""))
+    }
+  }
+
+  describe("Accept") {
     it("should extract type based on the extension first") {
       val req = new test.TestRequest("http://test.com/test.xml")
-      expectResult(Some("application/xml"))(ContentType.unapply(req))
+      expectResult(Some(List("application/xml")))(Accept.unapply(req))
     }
-    it("should extract type based on the header if there is no extension") {
-      val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "application/xml"))
-      expectResult(Some("application/xml"))(ContentType.unapply(req))
-    }
-    it("should extract type based on the last header if there is no extension and multiple headers") {
+    it("should extract type from the accept headers") {
       val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "application/json", "Accept" -> "application/xml"))
-      expectResult(Some("application/json"))(ContentType.unapply(req))
+      expectResult(List("application/json", "application/xml"))(Accept.unapply(req).head)
+    }
+    it("should extract type based on headers and extension, keeping extenstion the first in the list") {
+      val req = new test.TestRequest("http://test.com/test.xml", headers = Seq("Accept" -> "application/json", "Accept" -> "application/xml"))
+      expectResult(List("application/xml", "application/json"))(Accept.unapply(req).head)
     }
   }
 

--- a/src/test/scala/smoke/RequestTest.scala
+++ b/src/test/scala/smoke/RequestTest.scala
@@ -40,4 +40,16 @@ class RequestTest extends FunSpec {
       assert(req.queryParams === Map())
     }
   }
+
+  describe("accept method") {
+    it("should sort accept headers by q parameters") {
+      val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "text/plain;q=0.9", "Accept" -> "application/json", "Accept" -> "*/*;q=0.7", "Accept" -> "application/xml"))
+      assert(req.accept === List("application/json", "application/xml", "text/plain", "*/*"))
+    }
+
+    it("but also maintain the original order for the rest") {
+      val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "text/plain;q=0.9", "Accept" -> "application/xml", "Accept" -> "application/json"))
+      assert(req.accept === List("application/xml", "application/json", "text/plain"))
+    }
+  }
 }


### PR DESCRIPTION
Add request.accept method that reads the accept headers and sort mimetypes by priority (keeping the extension the first in the list)
