### PR TITLE
Renaming

### DIFF
--- a/src/main/scala/smoke/Request.scala
+++ b/src/main/scala/smoke/Request.scala
@@ -30,7 +30,7 @@ trait Request extends Headers {
   val contentLength: Int
 
   //Sort accept header by given priority (q=?)
-  lazy val accept: Seq[String] =
+  lazy val acceptHeaders: Seq[String] =
     allHeaderValues("accept").map {
       _.split(";").toList match {
         case mt :: p :: Nil ⇒ (mt, p.split("q=").last.toFloat)

--- a/src/main/scala/smoke/examples/FileNameExampleApp.scala
+++ b/src/main/scala/smoke/examples/FileNameExampleApp.scala
@@ -26,7 +26,7 @@ object FileNameExampleApp extends SmokeApp {
     //  Response(Ok, body = "No extension")
     //}
 
-    case GET(Seg("products" :: productId :: "docs" :: _ :: Nil) & Filename.name(document)) ⇒ reply {
+    case GET(Seg("products" :: productId :: "docs" :: _ :: Nil) & Filename.base(document)) ⇒ reply {
 
       document match {
         case "manual"   ⇒ Response(Ok, body = "1. Purchase our product. 2. ??? 3. Profit!")

--- a/src/main/scala/smoke/extractors.scala
+++ b/src/main/scala/smoke/extractors.scala
@@ -37,7 +37,7 @@ object Filename {
       }
     }
 
-  object name {
+  object base {
     def unapply(req: Request): Option[String] =
       unapply(req.path)
 
@@ -76,7 +76,7 @@ object Accept {
       (Filename.extension.unapply(req.path).
         map { ext ⇒ List(MimeType(ext)) }.
         getOrElse(List[String]()) ++
-        req.accept).distinct)
+        req.acceptHeaders).distinct)
 }
 
 object Params {

--- a/src/test/scala/smoke/ExtractorsTest.scala
+++ b/src/test/scala/smoke/ExtractorsTest.scala
@@ -74,30 +74,30 @@ class ExtractorsTest extends FunSpec {
     }
   }
 
-  describe("Filename.name") {
+  describe("Filename.base") {
 
     it("should extract basename with multiple periods") {
-      expectResult(Some("foo.bar.baz"))(Filename.name.unapply("/path/foo.bar.baz.m3u8"))
+      expectResult(Some("foo.bar.baz"))(Filename.base.unapply("/path/foo.bar.baz.m3u8"))
     }
 
     it("should extract basename with path segments") {
-      expectResult(Some("baz"))(Filename.name.unapply("/foo/bar/baz.m3u8"))
+      expectResult(Some("baz"))(Filename.base.unapply("/foo/bar/baz.m3u8"))
     }
 
     it("should extract a basename with no extension") {
-      expectResult(Some("foo"))(Filename.name.unapply("foo"))
+      expectResult(Some("foo"))(Filename.base.unapply("foo"))
     }
 
     it("should extract a basename ending with a period but no extension") {
-      expectResult(Some("foo"))(Filename.name.unapply("foo."))
+      expectResult(Some("foo"))(Filename.base.unapply("foo."))
     }
 
     it("should return None when it's an extension only") {
-      expectResult(None)(Filename.name.unapply(".foo"))
+      expectResult(None)(Filename.base.unapply(".foo"))
     }
 
     it("should return None for an empty string") {
-      expectResult(None)(Filename.name.unapply(""))
+      expectResult(None)(Filename.base.unapply(""))
     }
   }
 

--- a/src/test/scala/smoke/RequestTest.scala
+++ b/src/test/scala/smoke/RequestTest.scala
@@ -44,12 +44,12 @@ class RequestTest extends FunSpec {
   describe("accept method") {
     it("should sort accept headers by q parameters") {
       val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "text/plain;q=0.9", "Accept" -> "application/json", "Accept" -> "*/*;q=0.7", "Accept" -> "application/xml"))
-      assert(req.accept === List("application/json", "application/xml", "text/plain", "*/*"))
+      assert(req.acceptHeaders === List("application/json", "application/xml", "text/plain", "*/*"))
     }
 
     it("but also maintain the original order for the rest") {
       val req = new test.TestRequest("http://test.com/test", headers = Seq("Accept" -> "text/plain;q=0.9", "Accept" -> "application/xml", "Accept" -> "application/json"))
-      assert(req.accept === List("application/xml", "application/json", "text/plain"))
+      assert(req.acceptHeaders === List("application/xml", "application/json", "text/plain"))
     }
   }
 }


### PR DESCRIPTION
Renamed request.accept to request.acceptHeaders to make it clear that it does not include the extension. Renamed Filename.name to Filename.base.
