### PR TITLE
Fix issue with Match Error due to partial function chaining

### DIFF
--- a/src/main/scala/smoke/Session.scala
+++ b/src/main/scala/smoke/Session.scala
@@ -1,28 +1,21 @@
 package smoke
 
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.Config
-
 import javax.crypto.spec.SecretKeySpec
 import javax.crypto.Mac
 
 class SessionManager(appSecret: String) {
-  private val keySpec = new SecretKeySpec(appSecret.getBytes(), "HmacSHA1")
-  private val mac = Mac.getInstance("HmacSHA1")
-  mac.init(keySpec)
+  val mac = Mac.getInstance("HmacSHA1")
+  mac.init(new SecretKeySpec(appSecret.getBytes(), "HmacSHA1"))
 
   private[smoke] val CookieSignSeparator = "--"
-
-  private object SignedCookieValue {
-    def unapply(signedCookieValue: String) =
-      signedCookieValue.split(CookieSignSeparator).toList match {
-        case cookie :: signature :: Nil if (sign(cookie) == signature) ⇒
-          Some(cookie)
-        case x ⇒ None
-      }
+  private[smoke] def extractValids(signedCookieValue: String): Option[String] = {
+    val values = signedCookieValue.split(CookieSignSeparator)
+    if (values.size > 1 && sign(values(0)) == values(1)) {
+      Some(values(0))
+    } else None
   }
-
-  private[smoke] def sign(s: String) = mac.doFinal(s.getBytes("utf-8")).map(c ⇒ f"$c%02x").mkString
+  private[smoke] def sign(s: String): String =
+    mac.doFinal(s.getBytes("utf-8")).map(c ⇒ f"$c%02x").mkString
 
   object Session {
     //TODO Session Expiration on client side
@@ -30,13 +23,14 @@ class SessionManager(appSecret: String) {
       case (k, v) ⇒ "Set-Cookie" -> (k + "=" + v + CookieSignSeparator + sign(v))
     }
 
-    def unapply(req: Request) = {
+    def unapply(req: Request): Option[Map[String, String]] = {
       if (req.cookies.isEmpty) None
       else {
-        Some(req.cookies.collect {
-          case (key, SignedCookieValue(value)) ⇒ key -> value
-
-        } toMap)
+        Some(req.cookies.map {
+          case (k, v) ⇒ k -> extractValids(v)
+        } collect {
+          case (k, Some(v)) ⇒ (k -> v)
+        })
       }
     }
 

--- a/src/test/scala/smoke/SessionTest.scala
+++ b/src/test/scala/smoke/SessionTest.scala
@@ -5,7 +5,8 @@ import org.scalatest.FunSpec
 import smoke.test._
 
 class SessionTest extends FunSpec {
-  val sessionManager = new SessionManager("0sfi034nrosd23kaldasl")
+  val appSecret = "0sfi034nrosd23kaldasl"
+  val sessionManager = new SessionManager(appSecret)
   import sessionManager._
 
   describe("Create a session") {
@@ -20,8 +21,8 @@ class SessionTest extends FunSpec {
   describe("Extract a session from the cookies") {
     it("should return all the session values from the request") {
       val request = TestRequest("", headers = Seq(
-        "Cookie" -> (s"user=smoked" + CookieSignSeparator + sign("smoked")),
-        "Cookie" -> (s"timestamp=0000" + CookieSignSeparator + sign("0000"))))
+        "Cookie" -> (s"user=smoked--" + sign("smoked")),
+        "Cookie" -> (s"timestamp=0000--" + sign("0000"))))
       val Session(session) = request
       assert(session === Map("user" -> "smoked", "timestamp" -> "0000"))
     }


### PR DESCRIPTION
It was producing 500 errors randomly when using the Session extractor.
