### PR TITLE
Fix sample in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Smoke provides a DSL for building HTTP services using a simple request/response 
 	}
 
 	class BasicExampleSmoke extends Smoke {
-  		val smokeConfig = ConfigFactory.load().getConfig("smoke")
+  		val config = ConfigFactory.load().getConfig("smoke")
   		val executionContext = scala.concurrent.ExecutionContext.global
 
   		onRequest {


### PR DESCRIPTION
Whilst creating a g8 project for smoke I noticed that the config value is incorrect in the readme. It has to be called config to override so the sample in the readme won't run.
