### PR TITLE
Update build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ libraryDependencies ++= Seq(
   "io.netty" % "netty" % "3.7.0.Final",
   "com.typesafe" % "config" % "1.2.0",
   "com.typesafe.akka" %% "akka-actor" % "2.3.2",
-  "org.scalatest" %% "scalatest" % "2.1.3" % "test"
+  "org.scalatest" %% "scalatest" % "2.1.3" % "test",
+  "org.scala-lang.modules" %% "scala-xml" % "1.0.1"
 )
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"


### PR DESCRIPTION
Scalatest depends on scala-xml which has become a separated package since Scala 2.11.

Ref:
[1] https://github.com/scala/scala-xml
[2] https://groups.google.com/d/msg/scalatest-users/4X2OJwe1yXk/Vn093LJBJmcJ
