### PR TITLE
Static assets can be read from inside the jar

### DIFF
--- a/src/main/resources/public/test-asset.html2
+++ b/src/main/resources/public/test-asset.html2
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+
+  <head>
+    <title>Test</title>
+    <meta charset="utf-8" />
+  </head>
+
+  <body>
+		<h1>Hello, world!</h1>
+  </body>
+
+</html>

--- a/src/main/scala/smoke/examples/StaticAssetsApp.scala
+++ b/src/main/scala/smoke/examples/StaticAssetsApp.scala
@@ -4,7 +4,7 @@ import smoke._
 import com.typesafe.config.ConfigFactory
 
 object StaticAssetsSmoke extends SmokeApp with StaticAssets {
-  val publicFolder = "src/test/resources/public"
+  val publicFolder = "public"
   val smokeConfig = ConfigFactory.load().getConfig("smoke")
   val executionContext = scala.concurrent.ExecutionContext.global
 

--- a/src/test/scala/smoke/StaticAssetsTest.scala
+++ b/src/test/scala/smoke/StaticAssetsTest.scala
@@ -33,6 +33,10 @@ class StaticAssetsTest extends FunSpecLike {
       assert(response.headers === Seq("Content-Type" -> "text/html"))
       assert(response.body.asInstanceOf[RawData].data === bytes)
     }
+    it("should not load anything outside of the static assets folder.") {
+      val response = staticAssets.responseFromAsset("/../pixel.gif")
+      assert(response === Response(NotFound))
+    }
   }
 
 }


### PR DESCRIPTION
Static assets preload feature is not compatible with class loader resource reading.
Static assets now restricts access to the public folder only.
