### PR TITLE
StaticAssets does not list directory contents, fix StaticAssets compatibility with sbt run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your build.sbt
 
     libraryDependencies += "com.mdialog" %% "smoke" % "2.0.1" //for akka 2.2.+
 
-    libraryDependencies += "com.mdialog" %% "smoke" % "2.1.1" //for akka 2.3.+
+    libraryDependencies += "com.mdialog" %% "smoke" % "2.1.3" //for akka 2.3.+
 
 
 Smoke 2.+ is made for use with Scala 2.10. If you're using an older

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "smoke"
 
 organization := "com.mdialog"
 
-version := "2.1.2"
+version := "2.1.3"
 
 scalaVersion := "2.11.0"
 


### PR DESCRIPTION
Fix issue with sbt run where isStaticAssets was being too restrictive preventing to return files. Check that the resource is actually a file to prevent listing of the directories (url.openStream return a list of files in a string if it's a directory)
